### PR TITLE
Wheels2

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -15,8 +15,8 @@ export CIBW_ENVIRONMENT_WINDOWS="ZLIB_HOME='$ZLIB_HOME'"
 # cython for the Cython.Coverage plugin.
 export CIBW_TEST_REQUIRES="cython pytest pytest-cov coverage numpy nibabel"
 
-# Disable pypy and py27+win32bit builds
-export CIBW_SKIP="pp* cp27-win32"
+# Disable pypy builds
+export CIBW_SKIP="pp*"
 
 # Pytest makes it *very* awkward to run tests
 # from an installed package, and still find/

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -112,9 +112,12 @@ int _fseek_python(PyObject *f, int64_t offset, int whence) {
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
 
-    // We can't use PyObject_CallMethod because of an issue
-    // with building wheels on 32-bit OSes, so we have to
-    // manually build up the arguments instead.
+    // We can't use PyObject_CallMethod with multiple arguments
+    // because it causes tests with 32-bit OS wheels to fail,
+    // so we have to manually build up the arguments instead.
+    // TODO: File an issue with cpython about this.
+    // if ((data = PyObject_CallMethod(f, "seek", "(l,i)", offset, whence)) == NULL)
+    //     goto fail;
     if ((seek_fn_name = PyUnicode_FromString("seek")) == NULL)
         goto fail;
     if ((whence_ = PyLong_FromLong(whence)) == NULL)

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -46,7 +46,7 @@
  */
 size_t _fread_python(void *ptr, size_t size, size_t nmemb, PyObject *f) {
 
-    PyObject  *data;
+    PyObject  *data = NULL;
     char      *buf;
     Py_ssize_t len;
 
@@ -76,7 +76,7 @@ fail:
  * file-like objects.
  */
 int64_t _ftell_python(PyObject *f) {
-    PyObject *data;
+    PyObject *data = NULL;
     int64_t   result;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
@@ -105,20 +105,37 @@ fail:
  */
 int _fseek_python(PyObject *f, int64_t offset, int whence) {
 
-    PyObject *data;
+    PyObject *data = NULL;
+    PyObject *seek_fn_name = NULL;
+    PyObject *whence_ = NULL;
+    PyObject *offset_ = NULL;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
 
-    data = PyObject_CallMethod(f, "seek", "(l,i)", offset, whence);
-    if (data == NULL)
+    // We can't use PyObject_CallMethod because of an issue
+    // with building wheels on 32-bit OSes, so we have to
+    // manually build up the arguments instead.
+    if ((seek_fn_name = PyUnicode_FromString("seek")) == NULL)
+        goto fail;
+    if ((whence_ = PyLong_FromLong(whence)) == NULL)
+        goto fail;
+    if ((offset_ = PyLong_FromLong(offset)) == NULL)
+        goto fail;
+    if ((data = PyObject_CallMethodObjArgs(f, seek_fn_name, offset_, whence_, NULL)) == NULL)
         goto fail;
 
     Py_DECREF(data);
+    Py_DECREF(seek_fn_name);
+    Py_DECREF(whence_);
+    Py_DECREF(offset_);
     _ZRAN_FILE_UTIL_RELEASE_GIL
     return 0;
 
 fail:
     Py_XDECREF(data);
+    Py_XDECREF(seek_fn_name);
+    Py_XDECREF(whence_);
+    Py_XDECREF(offset_);
     _ZRAN_FILE_UTIL_RELEASE_GIL
     return -1;
 }
@@ -137,7 +154,7 @@ int _feof_python(PyObject *f, size_t f_ret) {
  * file-like objects.
  */
 int _ferror_python(PyObject *f) {
-    int result;
+    PyObject *result = NULL;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
     result = PyErr_Occurred();
@@ -152,7 +169,7 @@ int _ferror_python(PyObject *f) {
  * file-like objects.
  */
 int _fflush_python(PyObject *f) {
-    PyObject *data;
+    PyObject *data = NULL;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
     if ((data = PyObject_CallMethod(f, "flush", NULL)) == NULL) goto fail;
@@ -176,7 +193,7 @@ size_t _fwrite_python(const void *ptr,
                       size_t      nmemb,
                       PyObject   *f) {
 
-    PyObject *input;
+    PyObject *input = NULL;
     PyObject *data = NULL;
     long      len;
 


### PR DESCRIPTION
Fixes wheels building issues on 32-bit OSes.

We can't use PyObject_CallMethod with multiple arguments
because it causes tests with 32-bit OS wheels to fail,
so we have to manually build up the arguments in `_fseek_python`
instead.

We should probably eventually file an issue with cpython about this.

Additionally, this PR makes a few other changes:
- Ensures that `PyErr_Occurred()` is set to a `PyObject *`, not an `int`
- Ensures that all `PyObject *` variables are set to null instead of being uninitialized (we need to initialize them to null, because we end up calling `Py_XDECREF` on them)

Here's a GHA run that successfully builds wheels with the changes from this PR: https://github.com/epicfaace/indexed_gzip/runs/2156832656