### PR TITLE
Set all PyObject * variables to null

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -15,8 +15,8 @@ export CIBW_ENVIRONMENT_WINDOWS="ZLIB_HOME='$ZLIB_HOME'"
 # cython for the Cython.Coverage plugin.
 export CIBW_TEST_REQUIRES="cython pytest pytest-cov coverage numpy nibabel"
 
-# Disable pypy and py27+win32bit builds
-export CIBW_SKIP="pp* cp27-win32"
+# Disable pypy builds
+export CIBW_SKIP="pp*"
 
 # Pytest makes it *very* awkward to run tests
 # from an installed package, and still find/

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -46,7 +46,7 @@
  */
 size_t _fread_python(void *ptr, size_t size, size_t nmemb, PyObject *f) {
 
-    PyObject  *data;
+    PyObject  *data = NULL;
     char      *buf;
     Py_ssize_t len;
 
@@ -76,7 +76,7 @@ fail:
  * file-like objects.
  */
 int64_t _ftell_python(PyObject *f) {
-    PyObject *data;
+    PyObject *data = NULL;
     int64_t   result;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
@@ -105,10 +105,10 @@ fail:
  */
 int _fseek_python(PyObject *f, int64_t offset, int whence) {
 
-    PyObject *data;
-    PyObject *seek_fn_name;
-    PyObject *whence_;
-    PyObject *offset_;
+    PyObject *data = NULL;
+    PyObject *seek_fn_name = NULL;
+    PyObject *whence_ = NULL;
+    PyObject *offset_ = NULL;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
 
@@ -173,7 +173,7 @@ int _ferror_python(PyObject *f) {
  * file-like objects.
  */
 int _fflush_python(PyObject *f) {
-    PyObject *data;
+    PyObject *data = NULL;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
     if ((data = PyObject_CallMethod(f, "flush", NULL)) == NULL) goto fail;
@@ -197,7 +197,7 @@ size_t _fwrite_python(const void *ptr,
                       size_t      nmemb,
                       PyObject   *f) {
 
-    PyObject *input;
+    PyObject *input = NULL;
     PyObject *data = NULL;
     long      len;
 


### PR DESCRIPTION
Ensures that all PyObject * variables are set to null instead of being uninitialized (we need to initialize them to null, because we end up calling `Py_XDECREF` on them).